### PR TITLE
Modify isChannel to always return true for any MSTeams channel id

### DIFF
--- a/lib/handlers/command/slack/LinkRepo.ts
+++ b/lib/handlers/command/slack/LinkRepo.ts
@@ -115,7 +115,7 @@ export class LinkRepo implements HandleCommand {
             return ctx.messageClient.respond(err)
                 .then(() => Success, failure);
         }
-        if (isSlack(this.channelId) && !isChannel(this.channelId)) {
+        if (!isChannel(this.channelId)) {
             const err = "The Atomist Bot can only link repositories to public or private channels. " +
                 "Please try again in a public or private channel.";
             return ctx.messageClient.addressChannels(err, this.channelName)

--- a/lib/handlers/command/slack/LinkRepo.ts
+++ b/lib/handlers/command/slack/LinkRepo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/util/slack.ts
+++ b/lib/util/slack.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/util/slack.ts
+++ b/lib/util/slack.ts
@@ -22,7 +22,10 @@
  * @return true if the channel is a public channel
  */
 export function isChannel(id: string): boolean {
-    return id.indexOf("C") === 0 || id.indexOf("G") === 0;
+    if (isSlack(id)) {
+        return id.indexOf("C") === 0 || id.indexOf("G") === 0;
+    }
+    return true;
 }
 
 /**

--- a/test/util/slack.test.ts
+++ b/test/util/slack.test.ts
@@ -48,6 +48,10 @@ describe("slack", () => {
             });
         });
 
+        it("should accept any MS Team channel ID", () => {
+            assert(isChannel("12:a347e001ebcd4f02ab3a086c1ddb0a03@thread.skype"));
+        });
+
     });
 
     describe("checkIsSlack", () => {


### PR DESCRIPTION
Retains current behavior for Slack channel ids. Fixes #3 .